### PR TITLE
reestructuracion divisa

### DIFF
--- a/controlador/divisa.php
+++ b/controlador/divisa.php
@@ -110,7 +110,7 @@ if (isset($_POST['buscar'])) {
         } else if ($result == 0) {
             $eliminar = [
                 "title" => "Error",
-                "message" => "La divisa no se puede eliminar ya que tiene tipos de pago asociados",
+                "message" => "La divisa no se puede eliminar ya que tiene registros asociados",
                 "icon" => "error"
             ];
         } else {
@@ -162,6 +162,6 @@ if (isset($_POST['buscar'])) {
 }
 
 $historial = $obj->historial();
-$consulta = $obj->consultar();
+$consulta = $obj->consultarDivisas();
 $_GET['ruta'] = 'divisa';
 require_once 'plantilla.php';

--- a/modelo/divisa.php
+++ b/modelo/divisa.php
@@ -119,10 +119,16 @@ class Divisa extends Conexion
 
 
     public function consultarDivisas() {
-        $sql = "SELECT *FROM divisas";
+        parent::conectarBD();
+        $sql = "SELECT d.*, 
+            (SELECT cd.tasa FROM cambio_divisa cd WHERE cd.cod_divisa = d.cod_divisa ORDER BY cd.fecha DESC, cd.cod_cambio DESC LIMIT 1) AS tasa,
+            (SELECT cd.fecha FROM cambio_divisa cd WHERE cd.cod_divisa = d.cod_divisa ORDER BY cd.fecha DESC, cd.cod_cambio DESC LIMIT 1) AS fecha
+            FROM divisas d";
         $stmt = $this->conex->prepare($sql);
         $stmt->execute();
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $datos = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        parent::desconectarBD();
+        return $datos;
     }
 
     public function consultar(){
@@ -185,21 +191,21 @@ class Divisa extends Conexion
 
 
     public function eliminar($valor){
-        $registro="SELECT COUNT(*) AS v_count FROM cambio_divisa cd JOIN tipo_pago tp ON cd.cod_cambio = tp.cod_cambio WHERE cd.cod_divisa = $valor";
-        parent::conectarBD();
-        $strExec = $this->conex->prepare($registro);
-        $resul = $strExec->execute();
-        if($resul){
-            $resultado=$strExec->fetch(PDO::FETCH_ASSOC); 
-            if ($resultado['v_count']>0){
-                $r=0;
-            }else{
-                $fisico="DELETE FROM divisas WHERE cod_divisa=$valor";
-                $strExec=$this->conex->prepare($fisico);
-                $strExec->execute();
-                $r=1;
-                }
+        try {
+            parent::conectarBD();
+            $fisico = "DELETE FROM divisas WHERE cod_divisa = :cod_divisa";
+            $strExec = $this->conex->prepare($fisico);
+            $strExec->bindParam(':cod_divisa', $valor);
+            $strExec->execute();
+            $r = 1;
+        } catch (PDOException $e) {
+            // violacion de clave foranea
+            if ($e->getCode() == '23000') {
+                $r = 0;
+            } else {
+                throw $e; // volver a lanzar si es un error diferente
             }
+        }
         parent::desconectarBD();
         return $r;
     }

--- a/vista/dist/js/modulos-js/divisa.js
+++ b/vista/dist/js/modulos-js/divisa.js
@@ -124,6 +124,38 @@ $('#nombre1').blur(function (e){
 });
 
 //EDITAR
+$('#actModal').on('show.bs.modal', function (event) {
+    var button = $(event.relatedTarget);
+    var codigo = button.data('codigo');
+    var nombre = button.data('nombre');
+    var abreviatura = button.data('abreviatura');
+    var tasa = button.data('tasa');
+
+    // campos modal
+    var modal = $(this);
+    modal.find('.modal-body #codigo2').val(codigo);
+    modal.find('.modal-body #nombre2').val(nombre);
+    modal.find('.modal-body #abreviatura2').val(abreviatura);
+    modal.find('.modal-body #tasa2').val(tasa);
+
+    // actualizar datatabla historial
+    var historialFiltrado = historialDivisas.filter(function(item) {
+        return item.cod_divisa == codigo;
+    });
+
+    var tabla = $(this).find('#carga table').DataTable();
+    tabla.clear();
+    
+    historialFiltrado.forEach(function(item) {
+        tabla.row.add([
+            item.fecha,
+            item.tasa
+        ]);
+    });
+    
+    tabla.order([0, 'desc']).draw();
+});
+
 $('#editModal').on('show.bs.modal', function (event) {
     var button = $(event.relatedTarget);
     var codigo = button.data('codigo');
@@ -153,3 +185,4 @@ $('#eliminardivisa').on('show.bs.modal', function (event) {
     modal.find('#divisaNombre').text(nombre);
     modal.find('.modal-body #divisaCodigo').val(codigo);
 });
+

--- a/vista/modulos/divisa.php
+++ b/vista/modulos/divisa.php
@@ -41,7 +41,7 @@
                                 </thead>
                                 <tbody>
                                     <?php foreach ($consulta as $divisa) { ?>
-                                    <?php if ($divisa['divisa_status'] != 2): ?>
+                                    <?php if ($divisa['status'] != 2): ?>
                                     <tr>
                                         <td><?php echo $divisa['cod_divisa']?></td>
                                         <td><?php echo $divisa['nombre']?></td>
@@ -56,14 +56,14 @@
                                                 data-nombre="<?php echo $divisa["nombre"]; ?>" 
                                                 data-abreviatura="<?php echo $divisa["abreviatura"]; ?>"
                                                 data-tasa="<?php echo $divisa["tasa"]; ?>"
-                                                data-status="<?php echo $divisa["divisa_status"]; ?>" >
+                                                data-status="<?php echo $divisa["status"]; ?>" >
                                                 <i class="fa fa-history" aria-hidden="true"></i>
                                             </button>
                                             </div>
                                             <?php endif;?>
                                         </td>
                                         <td>
-                                            <?php if ($divisa['divisa_status']==1):?>
+                                            <?php if ($divisa['status']==1):?>
                                                 <span class="badge bg-success">Activo</span>
                                             <?php else:?>
                                                 <span class="badge bg-danger">Inactivo</span>
@@ -78,7 +78,7 @@
                                             data-nombre="<?php echo $divisa["nombre"]; ?>" 
                                             data-abreviatura="<?php echo $divisa["abreviatura"]; ?>"
                                             data-tasa="<?php echo $divisa["tasa"]; ?>"
-                                            data-status="<?php echo $divisa["divisa_status"]; ?>" >
+                                            data-status="<?php echo $divisa["status"]; ?>" >
                                             <i class="fas fa-pencil-alt"></i>
                                             </button>
                                             <button name="eliminar" title="Eliminar" class="btn btn-danger btn-sm eliminar" data-toggle="modal" data-target="#eliminardivisa"
@@ -354,18 +354,11 @@ MODAL ACTUALIZAR TASA DE CAMBIO
                                         <table class="table table-bordered table-striped datatable" style="width:100%">
                                             <thead>
                                                 <tr>
-                                                    <th>Fecha</th>
+                                                    <th data-orderable="true" data-order="desc">Fecha</th>
                                                     <th>Tasa</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                            <?php foreach ($historial as $histori) { ?>
-                                    <?php if ($histori['cod_divisa'] == 2): ?>
-                                    <tr>
-                                        <td><?php echo $histori['fecha']?></td>
-                                        <td><?php echo $histori['tasa']?></td>
-                                        <?php endif;
-                                        } ?>
                                             </tbody>
                                         </table>
                                     </div>
@@ -380,23 +373,10 @@ MODAL ACTUALIZAR TASA DE CAMBIO
 
 <script> 
 //ACTUALIZAR
-$('#actModal').on('show.bs.modal', function (event) {
-    var button = $(event.relatedTarget);
-    var codigo = button.data('codigo');
-    var nombre = button.data('nombre');
-    var origi = button.data('nombre');
-    var abreviatura = button.data('abreviatura');
-    var tasa = button.data('tasa');
-    var status = button.data('status');
+</script>
 
-    // Modal
-    var modal = $(this);
-    modal.find('.modal-body #codigo2').val(codigo);
-    modal.find('.modal-body #nombre2').val(nombre);
-    modal.find('.modal-body #abreviatura2').val(abreviatura);
-    modal.find('.modal-body #tasa2').val(tasa);
-    modal.find('.modal-body #status').val(status);
-});
+<script>
+    var historialDivisas = <?php echo json_encode($historial); ?>;
 </script>
 
 <script src='vista/dist/js/modulos-js/divisa.js'></script>


### PR DESCRIPTION
controlador/divisa

- cambié el mensaje de error por registros asociados
- nombre del método consultarDivisas


modelo/divisa.php

- consultarDivisas() ahora consulta las divisas individuales con su tasa actual.
- eliminar hora usa trycatch para eliminar, si da error de clave foránea (es decir, está asociada por ahí), retorna 0 (no se elimina)


vista/divisa

- divisa['divisa_status'] pasa a ser divisa['status']
- datatable de historial modificada para que se ordene por fecha
- javascript: usa la api de datatable para cargar los datos del historial de cada divisa